### PR TITLE
Deep copy blank nodes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -1,0 +1,10 @@
+pipeline:
+  build-and-push:
+    image: plugins/docker
+    settings:
+      repo: lblod/ldes-make-object-service
+      tags: "feature-${CI_COMMIT_BRANCH##feature/}"
+    secrets: [docker_username, docker_password]
+when:
+  event: push
+  branch: feature/*

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 Make an object from an ldes feed. It requires an ldes consumer and te delta notifier.
 
-### Introduction
+## Introduction
 
 The `ldes-consumer` consumes versions from an LDES feed. In order to make an object from
 the version, we must extract the proper subject from the `dct:isVersionOf`.
 
-This service is set to listen to delta messages, detects new inserts with a `dct:isVersionOf` 
+This service is set to listen to delta messages, detects new inserts with a `dct:isVersionOf`
 predicate, and update a `target graph` accordingly.
 
 In order to achieve this, the ldes consumer service must write ldes version to a `landing zone graph`.
 
-Here's an example: 
+Here's an example:
 
 ```yml
   consumer:
@@ -28,6 +28,34 @@ Here's an example:
     environment:
       LANDING_ZONE_GRAPH: "http://mu.semte.ch/graphs/ldes"
       TARGET_GRAPH: "http://mu.semte.ch/graphs/public"
-    links:
-      - database:database
 ```
+
+Add the following rule to the delta-notifier configuration in `./config/delta/rules.js`
+
+```javascript
+export default [
+  // ... other rules
+  {
+    match: {
+      predicate: { type: 'uri', value: 'http://purl.org/dc/terms/isVersionOf' }
+    },
+    callback: {
+      url: "http://make-object/delta",
+      method: "POST"
+    },
+    options: {
+      resourceFormat: "v0.0.1",
+      gracePeriod: 500,
+      ignoreFromSelf: true
+    }
+  }
+];
+```
+
+## Reference
+### Configuration
+The following environment variables can be configured on the service:
+- **LANDING_ZONE_GRAPH**: URI of the graph to which data of the LDES feed is written (default: `http://mu.semte.ch/graphs/ldes`)
+- **TARGET_GRAPH**: URI of the graph to which the consolidated objects must be written (default: `http://mu.semte.ch/graphs/public`)
+- **DEEP_COPY_BLANK_NODES**: If enabled nested blank nodes up to 3 levels deep will be copied to the target graph as well (default: `false`)
+- **BLANK_NODE_NAMESPACE**: Base URI of blank nodes in the LDES feed (default: `http://mu.semte.ch/blank#`)


### PR DESCRIPTION
Add environment variable `DEEP_COPY_BLANK_NODES` to enable copying of nested blank nodes. Currently up to 3 levels deep. Defaults to `false`.

Blank nodes are recognized based on the namespace which can be configured via `BLANK_NODE_NAMESPACE`. Defaults to `http://mu.semte.ch/blank#`.

Tested on the IPDC LDES feed in combination with the [ldes-consumer-service](https://github.com/redpencilio/ldes-consumer-service/tree/feature/use-streaming-backpressure).

Co-author @madnificent 