### PR TITLE
configurable predicate for isVersionOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ The following environment variables can be configured on the service:
 - **TARGET_GRAPH**: URI of the graph to which the consolidated objects must be written (default: `http://mu.semte.ch/graphs/public`)
 - **DEEP_COPY_BLANK_NODES**: If enabled nested blank nodes up to 3 levels deep will be copied to the target graph as well (default: `false`)
 - **BLANK_NODE_NAMESPACE**: Base URI of blank nodes in the LDES feed (default: `http://mu.semte.ch/blank#`)
+- **LDES_VERSION_OF_PATH**:  the predicate to be used to find the link to the non version object (default: `http://purl.org/dc/terms/isVersionOf`)

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ The following environment variables can be configured on the service:
 - **TARGET_GRAPH**: URI of the graph to which the consolidated objects must be written (default: `http://mu.semte.ch/graphs/public`)
 - **DEEP_COPY_BLANK_NODES**: If enabled nested blank nodes up to 3 levels deep will be copied to the target graph as well (default: `false`)
 - **BLANK_NODE_NAMESPACE**: Base URI of blank nodes in the LDES feed (default: `http://mu.semte.ch/blank#`)
-- **LDES_VERSION_OF_PATH**:  the predicate to be used to find the link to the non version object (default: `http://purl.org/dc/terms/isVersionOf`)
+- **LDES_VERSION_OF_PATH**: The predicate to be used to find the link to the non version object (default: `http://purl.org/dc/terms/isVersionOf`)

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ import { updateSudo } from "@lblod/mu-auth-sudo";
 import { Delta } from "./lib/delta";
 import bodyParser from "body-parser";
 
+const LDES_VERSION_OF_PATH = process.env.LDES_VERSION_OF_PATH || "http://purl.org/dc/terms/isVersionOf>";
 const LANDING_ZONE_GRAPH =
   process.env.LANDING_ZONE_GRAPH || "http://mu.semte.ch/graphs/ldes";
 const TARGET_GRAPH =
@@ -26,7 +27,7 @@ app.get("/", function (_, res) {
 app.post("/delta", async function (req, res, next) {
   try {
     const entries = new Delta(req.body).getInsertsFor(
-      "http://purl.org/dc/terms/isVersionOf",
+      LDES_VERSION_OF_PATH,
     );
     if (!entries.length) {
       console.debug("Delta dit not contain any interesting subjects.");
@@ -63,18 +64,18 @@ async function makeObject(subject) {
     }
     WHERE {
       GRAPH <${LANDING_ZONE_GRAPH}> {
-        <${subject}> <http://purl.org/dc/terms/isVersionOf> ?x .
+        <${subject}> <${LDES_VERSION_OF_PATH}> ?x .
       }
       {
         GRAPH <${LANDING_ZONE_GRAPH}> {
           ${!DEEP_COPY_BLANK_NODES
-            ? '<${subject}> ?p ?o . FILTER (?p != <http://purl.org/dc/terms/isVersionOf>)'
+            ? `<${subject}> ?p ?o . FILTER (?p != <${LDES_VERSION_OF_PATH}>)`
             : `{
                  <${subject}> ?p ?o .
-                 FILTER (?p != <http://purl.org/dc/terms/isVersionOf>)
+                 FILTER (?p != <${LDES_VERSION_OF_PATH}>)
                } UNION {
                  <${subject}> ?p ?o .
-                 FILTER (?p != <http://purl.org/dc/terms/isVersionOf>)
+                 FILTER (?p != <${LDES_VERSION_OF_PATH}>)
                  FILTER (STRSTARTS(STR(?o), "${BLANK_NODE_NAMESPACE}")) .
 
                  {


### PR DESCRIPTION
[The LDES consumer service](https://github.com/redpencilio/ldes-consumer-service)  makes  `LDES_VERSION_OF_PATH` configurable, added an option for that.

Also fixed a small issue from the previous PR that would break the case where blank node wasn't enabled:
```'<${subject}> ?p ?o . FILTER (?p != <${LDES_VERSION_OF_PATH}>)'```
should be
```
`<${subject}> ?p ?o . FILTER (?p != <${LDES_VERSION_OF_PATH}>)`
```